### PR TITLE
Add server test structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run test:client",
-    "test:client": "mocha ./test/server/.setup.js test/server/*.spec.js",
+    "test:client": "mocha ./test/server/.setup.js test/server/*.spec.js test/server/*/*.spec.js",
     "build": "webpack",
     "serve": "webpack-dev-server --content-base src --progress --watch --history-api-fallback --inline --hot --host 0.0.0.0 --port 9999"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Next Generation Photo Exploration App",
   "main": "index.js",
   "scripts": {
-    "test": "test",
+    "test": "npm run test:client",
+    "test:client": "mocha ./test/server/.setup.js test/server/*.spec.js",
     "build": "webpack",
     "serve": "webpack-dev-server --content-base src --progress --watch --history-api-fallback --inline --hot --host 0.0.0.0 --port 9999"
   },
@@ -43,8 +44,11 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "babel-runtime": "^6.3.13",
+    "chai": "^3.5.0",
     "css-loader": "^0.23.0",
     "json-loader": "^0.5.4",
+    "mocha": "^3.1.2",
+    "request": "^2.75.0",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0"

--- a/test/server/.setup.js
+++ b/test/server/.setup.js
@@ -1,0 +1,2 @@
+global.expect = require('chai').expect;
+global.request = require('request');

--- a/test/server/.setup.js
+++ b/test/server/.setup.js
@@ -1,2 +1,5 @@
+// Mocha will make these available as globals to all tests
+// which prevents us from having to manually require common modules
+// within each test file
 global.expect = require('chai').expect;
 global.request = require('request');

--- a/test/server/server.spec.js
+++ b/test/server/server.spec.js
@@ -1,0 +1,10 @@
+var server = require('../../app.js');
+
+describe('server', function() {
+  it('should pass a test', function(done) {
+    request(`http://localhost:9999`, function(error, res, body) {
+      expect(res.statusCode).to.equal(200);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This implements a file structure for server-side tests, installs the appropriate packages necessary as dev dependencies (`mocha`, `chai`, and `require` for now), and adds a `npm test:client` script to `package.json` that is run automatically by `npm test`. Additionally there is one sample sample that pings the server's index and ensures a 200 status code.

Closes #8