### PR TITLE
Update <Dome> to use new sphereMath code

### DIFF
--- a/client/src/components/Dome.js
+++ b/client/src/components/Dome.js
@@ -7,6 +7,8 @@ import React from 'react';
 import getDomePositions from '../util/sphereMath';
 import Image from './Image';
 
+const RADIUS = 6;
+
 const Dome = props => {
   const positions = getDomePositions(props.images.length, 1);
 
@@ -14,9 +16,9 @@ const Dome = props => {
     <Entity>
       {
         props.images.map((imageUrl, index) => {
-          const x = positions[index][0];
-          const y = positions[index][1];
-          const z = positions[index][2];
+          const x = positions[index][0] * RADIUS;
+          const y = positions[index][1] * RADIUS;
+          const z = positions[index][2] * RADIUS;
           return (
             <Image
             key={index}

--- a/client/src/components/Dome.js
+++ b/client/src/components/Dome.js
@@ -4,11 +4,11 @@ import 'aframe-text-component';
 import { Entity } from 'aframe-react';
 import React from 'react';
 
-import getSpherePositions from '../util/sphereMath';
+import getDomePositions from '../util/sphereMath';
 import Image from './Image';
 
 const Dome = props => {
-  const positions = getSpherePositions(props.images.length, 1);
+  const positions = getDomePositions(props.images.length, 1);
 
   return (
     <Entity>

--- a/client/src/components/Image.js
+++ b/client/src/components/Image.js
@@ -5,8 +5,8 @@ const Image = props => (
   <Entity
     geometry={{
       primitive: 'box',
-      width: 0.8,
-      height: 0.8,
+      width: 1.5,
+      height: 1.5,
       depth: 0
     }}
     position={props.position}

--- a/client/src/util/sphereMath.js
+++ b/client/src/util/sphereMath.js
@@ -1,3 +1,4 @@
+
 var createPoint = function(r, theta, phi) {
 
   var x = r * Math.sin(theta) * Math.cos(phi);
@@ -7,18 +8,36 @@ var createPoint = function(r, theta, phi) {
   return [x, y, z];
 };
 
-var getSpherePositions = function(N, r) {
+
+// spherePositions function generates an array of arrays [x, y, z], each denoting a position
+// on the surface of the sphere. Inputs N represents the number of desired points and r represents
+// the desired radius of the sphere. The center of the sphere will be [0, 0, 0].
+var spherePositions = function(N, r) {
   var positions = [];
 
+  // algorithm approximates each position to occupy the same area of a sphere,
+  // in a layout that places the positions in concentric horizontal circles.
+
   var nCount = 0;
+  // divides area of a sphere by the number of points
   var a = 4 * Math.PI * Math.pow(r, 2) / N;
+  // square roots the area to find height/width of each square
   var d = Math.pow(a, 0.5);
+
+  // sets interval m0
   var m0 = Math.round(Math.PI / d);
+
+  // splits 180 degrees by the number of intervals
+  // assume vertical distance
   var d0 = Math.PI / m0;
+  // divides area by vertical distance
+  // to compute the horizontal distance
   var dP = a / d0;
+
+  // generates positions by traversing through intervals
   for (var m = 0; m < m0; m++) {
     var theta = Math.PI * (m + 0.5) / m0;
-    var mP = Math.round(2 * Math.PI * theta / dP);
+    var mP = Math.round(2 * Math.PI * Math.sin(theta) / dP);
     for (var n = 0; n < mP; n++) {
       var phi = 2 * Math.PI * n / mP;
       positions.push(createPoint(r, theta, phi));
@@ -28,4 +47,11 @@ var getSpherePositions = function(N, r) {
   return positions;
 };
 
-export default getSpherePositions;
+// domePositions takes the first half positions
+// and generates the positions in a dome
+var domePositions = function(n, r) {
+  return spherePositions(2 * n, r).slice(0, n);
+};
+
+
+export default domePositions;

--- a/sphere-math/sphereMath.js
+++ b/sphere-math/sphereMath.js
@@ -23,13 +23,13 @@ var spherePositions = function(N, r) {
 
   // algorithm approximates each position to occupy the same area of a sphere,
   // in a layout that places the positions in concentric horizontal circles.
-  
+
   var nCount = 0;
   // divides area of a sphere by the number of points
   var a = 4 * Math.PI * Math.pow(r, 2) / N;
   // square roots the area to find height/width of each square
   var d = Math.pow(a, 0.5);
-  
+
   // sets interval m0
   var m0 = Math.round(Math.PI / d);
 
@@ -83,8 +83,9 @@ $( document ).ready(function() {
     marker: {
       size: 12,
       line: {
-      color: 'rgba(217, 217, 217, 0.14)',
-      width: 0.5},
+        color: 'rgba(217, 217, 217, 0.14)',
+        width: 0.5
+      },
       opacity: 0.8},
     type: 'scatter3d'
   };

--- a/test/client/util/sphereMath.spec.js
+++ b/test/client/util/sphereMath.spec.js
@@ -1,11 +1,13 @@
 import { expect } from 'chai';
-import getSpherePositions from '../../../client/src/util/sphereMath';
+import getDomePositions from '../../../client/src/util/sphereMath';
 
 describe('sphereMath', () => {
   it('generates the specified number of points', () => {
-    const expectedLength = 10;
-    const positions = getSpherePositions(expectedLength, 1);
-    console.log(positions);
-    // expect(positions.length).to.equal(expectedLength);
+    const expectedLength1 = 10;
+    const expectedLength2 = 200;
+    const positions1 = getDomePositions(expectedLength1, 1);
+    const positions2 = getDomePositions(expectedLength2, 1);
+    expect(positions1.length).to.equal(expectedLength1);
+    expect(positions2.length).to.equal(expectedLength2);
   });
 });


### PR DESCRIPTION
Based on @tankwan's fixed version of the sphereMath module, I have updated the util version of the module in our client folder, and re-enabled the test for sphereMath.

It's actually still a bit weird, though; it renders a dome *behind* the starting point, rather than in front.