### PR TITLE
(test) Install & use karma-mocha-reporter

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -51,7 +51,8 @@ module.exports = function(config) {
       'karma-webpack',
       'karma-jasmine',
       'karma-sourcemap-loader',
-      'karma-chrome-launcher'
+      'karma-chrome-launcher',
+      'karma-mocha-reporter'
     ],
 
     babelPreprocessor: {
@@ -64,7 +65,7 @@ module.exports = function(config) {
       }
     },
 
-    reporters: ['progress'],
+    reporters: ['mocha'],
     port: 9998,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-jasmine": "^1.0.2",
     "karma-mocha": "^1.2.0",
+    "karma-mocha-reporter": "^2.2.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.8.0",
     "mocha": "^3.1.2",


### PR DESCRIPTION
This just installs a new package that makes the output of our karma tests look a bit nicer and more like the spec reporter in mocha, and uses said package inside our karma config.