### PR TITLE
(fix) Change dome placement to be in front of camera

### DIFF
--- a/client/src/components/Dome.js
+++ b/client/src/components/Dome.js
@@ -18,7 +18,9 @@ const Dome = props => {
         props.images.map((imageUrl, index) => {
           const x = positions[index][0] * RADIUS;
           const y = positions[index][1] * RADIUS;
-          const z = positions[index][2] * RADIUS;
+
+          // The negative flips all items from behind the camera to in front
+          const z = positions[index][2] * -RADIUS;
           return (
             <Image
             key={index}


### PR DESCRIPTION
Formerly, the points generated by the `sphereMath` module were putting items _behind_ the camera in our scene, so the user would have to turn around to see the dome. A small change inside the `<Dome>` component ensures that now they're instead rendered in front of the camera (this was done by multiplying the z-coordinate of each photo by -1) rather than behind. 