### PR TITLE
(fix) material-ui/MenuItem does not throw error

### DIFF
--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import MenuItem from 'material-ui/MenuItem';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import injectTapEventPlugin from 'react-tap-event-plugin';
+import FileListener from './uploadImage';
 
 injectTapEventPlugin();
 
@@ -27,8 +28,8 @@ class Sidebar extends React.Component {
     return (
       <MuiThemeProvider>  
         <div>
-            <MenuItem>Home</MenuItem>
-            <MenuItem>Upload Image</MenuItem>
+          <a href="/"><MenuItem>Home</MenuItem></a>
+          <MenuItem>Upload Image</MenuItem>
         </div>
       </MuiThemeProvider>
     );

--- a/client/src/components/uploadImage.js
+++ b/client/src/components/uploadImage.js
@@ -1,18 +1,25 @@
 import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
-import CancelButton 'react-fine-uploader/components/cancel-button'
+import CancelButton from 'react-fine-uploader/components/cancel-button'
 import FineUploaderTraditional from 'react-fine-uploader'
-import Thumbnail 'react-fine-uploader/components/thumbnail'
+import Thumbnail from 'react-fine-uploader/components/thumbnail'
 
-const uploader = new FineUploader({
+const uploader = new FineUploaderTraditional({
    options: {
       request: {
          endpoint: 'my/upload/endpoint'
       }
    }
-})
+});
 
-export default class FileListener extends Component {
+const isFileGone = status => {
+  return [
+    'canceled',
+    'deleted',
+  ].indexOf(status) >= 0
+}
+
+class FileListener extends Component {
   constructor() {
     super()
     this.state = {
@@ -44,16 +51,11 @@ export default class FileListener extends Component {
               <Thumbnail id={ id } uploader={ uploader } />
               <CancelButton id={ id } uploader={ uploader } />
             </div>
-          ))
+          })
         }
       </div>
     )
   }
 }
 
-const isFileGone = status => {
-  return [
-    'canceled',
-    'deleted',
-  ].indexOf(status) >= 0
-}
+export default FileListener;

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "pg": "^6.1.0",
     "pg-hstore": "^2.3.2",
     "react": "^15.3.2",
+    "react-addons-css-transition-group": "^15.3.2",
     "react-dom": "^15.3.2",
+    "react-fine-uploader": "^0.1.1",
     "react-tap-event-plugin": "^1.0.0",
     "sequelize": "^3.24.4",
     "webpack": "^1.12.9"


### PR DESCRIPTION
material-ui/MenuItem was throwing a module error. This should no longer happen.