### PR TITLE
(fix) Move style-loader package to regular deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-fine-uploader": "^0.1.1",
     "react-tap-event-plugin": "^1.0.0",
     "sequelize": "^3.24.4",
+    "style-loader": "^0.13.0",
     "webpack": "^1.12.9"
   },
   "devDependencies": {
@@ -92,7 +93,6 @@
     "react-addons-test-utils": "^15.3.2",
     "request": "^2.75.0",
     "sinon": "^1.17.6",
-    "style-loader": "^0.13.0",
     "webpack-dev-server": "^1.14.0"
   }
 }


### PR DESCRIPTION
The `style-loader` package, which is needed by one of the front-end React modules we're loading, was inside `devDependencies` rather than simply `dependencies`, so when Heroku tried to build our bundle.js, the package was not installed and therefore not found, messing up our build. This simply moves the package to the `dependencies` section.