### PR TITLE
Bug/html meta

### DIFF
--- a/client/app.html
+++ b/client/app.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>A-Frame React Boilerplate</title>
   </head>
-  
+
   <body>
     <div class="scene-container" style="height: 100%; width: 100%"></div>
     <script src="/build/bundle.js"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -2,6 +2,9 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+    
     <title>Welcome</title>
     <link href="/assets/styles.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Indie+Flower" rel="stylesheet">


### PR DESCRIPTION
Both of our html pages were missing the `<meta charset="utf-8">` tag in the document `<head>`, and our welcome page also needed the [viewport meta](https://developers.google.com/speed/docs/insights/ConfigureViewport) tag. I think our actual app (`app.html`) doesn't need the viewport meta tag; it seems like A-Frame takes care of that stuff for us.