### PR TITLE
(feat) Touch up plotly viz to be clean of axes and text and color scheme to reflect photodome product

### DIFF
--- a/sphere-math/sphereMath.js
+++ b/sphere-math/sphereMath.js
@@ -64,6 +64,74 @@ var number = 250;
 // var testPositions = spherePositions(number, 1);
 var testPositions = domePositions(number, 1);
 
+// Plotly configurations
+var plotlyConfig = {
+
+    // no interactivity, for export or image generation
+    staticPlot: false,
+
+    // we can edit titles, move annotations, etc
+    editable: false,
+
+    // plot will respect layout.autosize=true and infer its container size
+    autosizable: true,
+
+    // if we DO autosize, do we fill the container or the screen?
+    fillFrame: true,
+
+    // if we DO autosize, set the frame margins in percents of plot size
+    frameMargins: true,
+
+    // mousewheel or two-finger scroll zooms the plot
+    scrollZoom: true,
+
+    // double click interaction (false, 'reset', 'autosize' or 'reset+autosize')
+    doubleClick: 'reset+autosize',
+
+    // new users see some hints about interactivity
+    showTips: false,
+
+    // link to open this plot in plotly
+    showLink: false,
+
+    // if we show a link, does it contain data or just link to a plotly file?
+    sendData: false,
+
+    // text appearing in the sendData link
+    linkText: '',
+
+    // false or function adding source(s) to linkText <text>
+    showSources: false,
+
+    // display the mode bar (true, false, or 'hover')
+    displayModeBar: false,
+
+    // remove mode bar button by name
+    // (see ./components/modebar/buttons.js for the list of names)
+    modeBarButtonsToRemove: [],
+
+    // add mode bar button using config objects
+    // (see ./components/modebar/buttons.js for list of arguments)
+    modeBarButtonsToAdd: [],
+
+    // fully custom mode bar buttons as nested array,
+    // where the outer arrays represents button groups, and
+    // the inner arrays have buttons config objects or names of default buttons
+    // (see ./components/modebar/buttons.js for more info)
+    modeBarButtons: false,
+
+    // add the plotly logo on the end of the mode bar
+    displaylogo: false,
+
+    // URL to topojson files used in geo charts
+    topojsonURL: 'https://cdn.plot.ly/',
+
+    // Turn all console logging on or off (errors will be thrown)
+    // This should ONLY be set via Plotly.setPlotConfig
+    logging: true,
+};
+
+
 $( document ).ready(function() {
 
   var xPos = [];
@@ -77,28 +145,57 @@ $( document ).ready(function() {
   });
 
 
-  var trace = {
+  var photos = {
     x: xPos, y: yPos, z: zPos,
     mode: 'markers',
     marker: {
+      color: 'rgb(81, 45, 168)',
       size: 12,
       line: {
-      color: 'rgba(217, 217, 217, 0.14)',
-      width: 0.5
+        color: 'rgba(217, 217, 217, 0.14)',
+        width: 0.5
       },
       symbol: 'square',
       opacity: 0.8},
     type: 'scatter3d'
   };
 
-  var data = [trace];
-  var layout = {margin: {
-    l: 0,
-    r: 0,
-    b: 0,
-    t: 0
-  }};
+  var person = {
+    x: [0], y: [0], z: [0.1],
+    mode: 'markers',
+    marker: {
+      color: 'rgb(179,157,219)',
+      size: 12,
+      line: {
+        color: 'rgba(217, 217, 217, 0.14)',
+        width: 0.5
+      },
+      symbol: 'diamond',
+      opacity: 0.8},
+    type: 'scatter3d'
+  };
 
-  Plotly.newPlot('myDiv', data, layout);
+  var axisTemplate = {
+    showticklabels: false,
+    title: ''
+  };
+
+  var data = [photos, person];
+  var layout = {
+    margin: {
+      l: 0,
+      r: 0,
+      b: 0,
+      t: 0
+    },
+    scene: {
+      xaxis: axisTemplate,
+      yaxis: axisTemplate,
+      zaxis: axisTemplate
+    },
+    showlegend: false  
+  };
+
+  Plotly.newPlot('myDiv', data, layout, plotlyConfig);
 
 });


### PR DESCRIPTION
Went through plotly documentation to hide axes, tick marks, and top bars, for clean presentation in homepage. Amended the color scheme to reflect product color schemes as well.