### PR TITLE
Make uglify to work based on production check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Next Generation Photo Exploration App",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npm run build",
+    "postinstall": "npm run build:prod",
     "start": "node app.js",
     "test": "npm run test:client && npm run test:server",
     "test:client": "karma start --single-run",
@@ -12,6 +12,7 @@
     "test:server": "mocha ./test/server/.setup.js test/server/*.spec.js test/server/*/*.spec.js",
     "lint": "eslint ./",
     "build": "webpack",
+    "build:prod": "webpack --prod",
     "build:watch": "webpack --watch",
     "serve": "webpack-dev-server --content-base client --progress --watch --history-api-fallback --inline --hot --host 0.0.0.0 --port 9999"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,8 @@ var path = require('path');
 var webpack = require('webpack');
 require('babel-polyfill');
 
-var IS_PRODUCTION = process.env.NODE_ENV === 'production';
+//var IS_PRODUCTION = process.env.NODE_ENV === 'production';
+var IS_PRODUCTION = process.argv.indexOf('--prod') !== -1;
 
 var ENTRY_POINTS = [
   './client/src/app'


### PR DESCRIPTION
Add a check if uglify has to be run in the case of production environment
webpack.js checks if prod variable is passed as par of invoking webpack